### PR TITLE
Add basic Jest tests

### DIFF
--- a/src/__tests__/CloseModal.test.jsx
+++ b/src/__tests__/CloseModal.test.jsx
@@ -7,9 +7,12 @@ jest.mock('react-ga4', () => ({
   send: jest.fn(),
 }));
 
-test('clicking a move displays its modal', () => {
+test('clicking the close button hides the modal', () => {
   render(<App />);
   const firstMove = screen.getByText('Hip throw');
   fireEvent.click(firstMove);
   expect(screen.getByRole('heading', { name: 'Hip throw' })).toBeInTheDocument();
+  const closeButton = screen.getByRole('button', { name: /close/i });
+  fireEvent.click(closeButton);
+  expect(screen.queryByRole('heading', { name: 'Hip throw' })).not.toBeInTheDocument();
 });

--- a/src/__tests__/Footer.test.jsx
+++ b/src/__tests__/Footer.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Footer from '../components/Footer';
+
+test('renders MIT Licensed text', () => {
+  render(<Footer />);
+  expect(screen.getByText(/MIT Licensed/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add tests for closing modal and footer rendering
- clean up existing App test

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847827ea20c832daeec4db11966cdce